### PR TITLE
Fix Vite base path for Django development server

### DIFF
--- a/backend/blackbox/settings.py
+++ b/backend/blackbox/settings.py
@@ -14,9 +14,10 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'corsheaders',
     'api',
-    'blackbox', 
-    'django_vite',
+    'blackbox',
 ]
+
+INSTALLED_APPS += ['django_vite']
 
 MIDDLEWARE = [
     'corsheaders.middleware.CorsMiddleware',
@@ -56,7 +57,7 @@ DATABASES = {
     }
 }
 
-DJANGO_VITE_DEV_MODE = DEBUG
+DJANGO_VITE_DEV_MODE = True
 DJANGO_VITE_DEV_SERVER_HOST = "127.0.0.1"
 DJANGO_VITE_DEV_SERVER_PORT = 5173
 

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -3,14 +3,16 @@ import react from "@vitejs/plugin-react";
 import { fileURLToPath, URL } from "node:url";
 
 export default defineConfig(({ mode }) => ({
+  base: mode === "production" ? "/static/" : "/",
   plugins: [react()],
-  base: mode === "development" ? "/" : "/static/",
-  resolve: { alias: { "@": fileURLToPath(new URL("./src", import.meta.url)) } },
+  resolve: {
+    alias: { "@": fileURLToPath(new URL("./src", import.meta.url)) },
+  },
   server: {
     host: "127.0.0.1",
     port: 5173,
     strictPort: true,
-    hmr: { host: "127.0.0.1", protocol: "ws", clientPort: 5173 },
+    hmr: { host: "127.0.0.1", port: 5173 },
   },
   build: {
     outDir: "../backend/static/.vite",


### PR DESCRIPTION
## Summary
- Configure Vite base path to `/` in dev and `/static/` in production
- Explicitly enable django-vite in Django settings for dev server

## Testing
- `npm run build`
- `python manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_68acb3824864832f9180126ed729dd7c