### PR TITLE
Fix Vite dev integration and React Router fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
 # BlackBox2.0
+
+## Development
+
+Run both servers in separate terminals:
+
+```bash
+# terminal 1
+cd frontend
+npm run dev
+
+# terminal 2
+python manage.py runserver
+```

--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -1,0 +1,6 @@
+from django.urls import path
+from .views import redeem
+
+urlpatterns = [
+    path('promo/redeem', redeem),
+]

--- a/backend/blackbox/settings.py
+++ b/backend/blackbox/settings.py
@@ -58,11 +58,23 @@ DATABASES = {
 }
 
 DJANGO_VITE_DEV_MODE = True
+DJANGO_VITE_DEV_SERVER_PROTOCOL = "http"
 DJANGO_VITE_DEV_SERVER_HOST = "127.0.0.1"
 DJANGO_VITE_DEV_SERVER_PORT = 5173
 
-DJANGO_VITE_ASSETS_PATH = BASE_DIR / "static" / ".vite"
-DJANGO_VITE_MANIFEST_PATH = DJANGO_VITE_ASSETS_PATH / "manifest.json"
+DJANGO_VITE_ASSETS_PATH = BASE_DIR.parent / "frontend" / "dist"
+DJANGO_VITE_MANIFEST_PATH = DJANGO_VITE_ASSETS_PATH / ".vite" / "manifest.json"
+
+DJANGO_VITE = {
+    "default": {
+        "dev_mode": True,
+        "dev_server_protocol": "http",
+        "dev_server_host": "127.0.0.1",
+        "dev_server_port": 5173,
+        "manifest_path": DJANGO_VITE_MANIFEST_PATH,
+        "static_url_prefix": "../",
+    }
+}
 
 
 LANGUAGE_CODE = 'en-us'

--- a/backend/blackbox/urls.py
+++ b/backend/blackbox/urls.py
@@ -1,11 +1,10 @@
 from django.contrib import admin
-from django.urls import path, re_path
+from django.urls import path, re_path, include
 from django.views.generic import TemplateView
-from api.views import redeem
 
 urlpatterns = [
-    path('admin/', admin.site.urls),
-    path('api/promo/redeem', redeem),
-    re_path(r'^(?!api/).*$',
-            TemplateView.as_view(template_name='index.html')),
+    path("admin/", admin.site.urls),
+    path("api/", include("api.urls")),
+    re_path(r"^(?!admin/|api/|static/|media/).*$",
+            TemplateView.as_view(template_name="index.html")),
 ]

--- a/backend/templates/index.html
+++ b/backend/templates/index.html
@@ -5,9 +5,8 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <title>Blackbox — Torn Casino & Raffles</title>
-
-    {% vite_hmr_client %}         {# dev only; no-op in prod #}
-    {% vite_react_refresh %}      
+    {% vite_hmr_client %}
+    {% vite_react_refresh %}
     {% vite_asset 'src/main.jsx' %}
   </head>
   <body>

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,13 +1,13 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
-import './index.css'
 import App from './App.jsx'
+import './index.css'
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
     <BrowserRouter>
       <App />
     </BrowserRouter>
-  </React.StrictMode>,
+  </React.StrictMode>
 )

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,22 +1,23 @@
-import { defineConfig } from "vite";
-import react from "@vitejs/plugin-react";
-import { fileURLToPath, URL } from "node:url";
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+import { fileURLToPath, URL } from 'node:url'
 
-export default defineConfig(({ mode }) => ({
-  base: mode === "production" ? "/static/" : "/",
+export default defineConfig({
   plugins: [react()],
-  resolve: {
-    alias: { "@": fileURLToPath(new URL("./src", import.meta.url)) },
-  },
+  root: './',
   server: {
-    host: "127.0.0.1",
+    host: '127.0.0.1',
     port: 5173,
     strictPort: true,
-    hmr: { host: "127.0.0.1", port: 5173 },
+    hmr: { host: '127.0.0.1', port: 5173, protocol: 'ws' }
+  },
+  base: '/',
+  resolve: {
+    alias: { '@': fileURLToPath(new URL('./src', import.meta.url)) }
   },
   build: {
-    outDir: "../backend/static/.vite",
+    outDir: './dist',
     manifest: true,
-    rollupOptions: { input: "/src/main.jsx" },
+    emptyOutDir: true,
   },
-}));
+})


### PR DESCRIPTION
## Summary
- configure django-vite for Vite dev server on 127.0.0.1:5173
- serve React entry via Django template and add catch‑all URL for SPA routes
- document dev commands and ensure BrowserRouter mounts to `#root`

## Testing
- `npm run dev` (fails: Unknown env config warning but server ready)
- `python manage.py check` (warn: STATICFILES_DIRS dir does not exist)
- `curl -I http://127.0.0.1:5173/@vite/client`
- `curl -I http://127.0.0.1:5173/@react-refresh`
- `curl -I http://127.0.0.1:5173/src/main.jsx`
- `curl -I http://127.0.0.1:8000/`
- `curl -I http://127.0.0.1:8000/faq`


------
https://chatgpt.com/codex/tasks/task_e_68acb51e2d08832f99f149119e0ff8c0