### PR TITLE
Refine dark UI styling and add winners ticker

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -6,7 +6,6 @@ import Raffles from '@/pages/Raffles.jsx'
 import Winners from '@/pages/Winners.jsx'
 import About from '@/pages/About.jsx'
 import HowItWorks from '@/components/HowItWorks.jsx'
-import Container from '@/components/Layout/Container.jsx'
 import DevPanel from '@/components/DevPanel.jsx'
 
 export default function App() {
@@ -56,48 +55,33 @@ export default function App() {
   }
 
   return (
-    <div className="min-h-screen bg-ink-900 text-zinc-100 selection:bg-zinc-200 selection:text-black">
-      {/* Background grid */}
-      <div aria-hidden className="pointer-events-none fixed inset-0 -z-10">
-        <div className="absolute inset-0 bg-[radial-gradient(80rem_50rem_at_50%_-20%,rgba(255,255,255,0.06),transparent)]" />
-        <div className="absolute inset-0 opacity-[0.07] [mask-image:radial-gradient(60rem_40rem_at_center,black,transparent)]">
-          <svg className="h-full w-full" xmlns="http://www.w3.org/2000/svg">
-            <defs>
-              <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse">
-                <path d="M 40 0 L 0 0 0 40" fill="none" stroke="white" strokeWidth="0.5" />
-              </pattern>
-            </defs>
-            <rect width="100%" height="100%" fill="url(#grid)" />
-          </svg>
-        </div>
-      </div>
+    <>
+      <NavBar
+        credits={credits}
+        loggedIn={loggedIn}
+        avatarUrl={avatarUrl}
+        onSimLogin={() => { setLoggedIn(true); setAvatarUrl('https://cdn.discordapp.com/embed/avatars/1.png') }}
+        onLogout={() => { setLoggedIn(false); setAvatarUrl(null) }}
+      />
 
-      <Container className="my-6">
-        <NavBar
-          credits={credits}
-          loggedIn={loggedIn}
-          avatarUrl={avatarUrl}
-          onSimLogin={() => { setLoggedIn(true); setAvatarUrl('https://cdn.discordapp.com/embed/avatars/1.png') }}
-          onLogout={() => { setLoggedIn(false); setAvatarUrl(null) }}
-        />
-
-        <main className="space-y-10">
-          <Routes>
-            <Route path="/" element={
-              <Home
-                promoCode={promoCode}
-                setPromoCode={setPromoCode}
-                promoMsg={promoMsg}
-                onRedeem={handleRedeem}
-              />
-            } />
-            <Route path="/how" element={<HowItWorks />} />
-            <Route path="/raffles" element={<Raffles raffles={raffles} />} />
-            <Route path="/winners" element={<Winners winners={winners} />} />
-            <Route path="/about" element={<About />} />
-            <Route path="*" element={<NotFound />} />
-          </Routes>
-
+      <main>
+        <Routes>
+          <Route path="/" element={
+            <Home
+              promoCode={promoCode}
+              setPromoCode={setPromoCode}
+              promoMsg={promoMsg}
+              onRedeem={handleRedeem}
+              winners={winners}
+            />
+          } />
+          <Route path="/how" element={<HowItWorks />} />
+          <Route path="/raffles" element={<Raffles raffles={raffles} />} />
+          <Route path="/winners" element={<Winners winners={winners} />} />
+          <Route path="/about" element={<About />} />
+          <Route path="*" element={<NotFound />} />
+        </Routes>
+        <div className="container">
           <DevPanel
             setPromoCode={setPromoCode}
             setPromoMsg={setPromoMsg}
@@ -105,19 +89,21 @@ export default function App() {
             setLoggedIn={setLoggedIn}
             setAvatarUrl={setAvatarUrl}
           />
-        </main>
+        </div>
+      </main>
 
-        <footer className="mt-12 border-t border-white/10 py-8 text-center text-xs text-zinc-400">
+      <footer className="section">
+        <div className="container text-center text-xs text-zinc-400">
           <p>© {new Date().getFullYear()} Blackbox — Unofficial, community-run. Not affiliated with Torn LTD.</p>
-        </footer>
-      </Container>
-    </div>
+        </div>
+      </footer>
+    </>
   )
 }
 
 function NotFound() {
   return (
-    <div className="rounded-2xl border border-white/10 bg-white/5 p-6 text-center">
+    <div className="card p-6 text-center">
       <h2 className="text-xl font-semibold">Page not found</h2>
       <p className="text-sm text-zinc-400">The page you’re looking for doesn’t exist.</p>
     </div>

--- a/frontend/src/components/HowItWorks.jsx
+++ b/frontend/src/components/HowItWorks.jsx
@@ -2,29 +2,31 @@ import React from 'react'
 
 export default function HowItWorks() {
   return (
-    <section id="how" className="mt-10">
-      <h2 className="text-2xl sm:text-3xl font-bold tracking-tight">How it works</h2>
-      <div className="mt-6 grid gap-4 sm:grid-cols-3">
-        {[
-          ['1. Send Xanax', 'Send 1x Xanax to Crikelz [2277924].', 'https://www.torn.com/profiles.php?XID=2277924'],
-          ['2. Wait a minute', 'Credits appear in your Blackbox balance automatically.', null],
-          ['3. Play', 'Join raffles or try Instant Wins. Payouts are instant.', null],
-        ].map(([h, s, link]) => (
-          <div key={h} className="rounded-2xl border border-white/10 bg-white/5 p-4">
-            <p className="text-sm font-semibold">{h}</p>
-            <p className="text-sm text-zinc-300">
-              {link ? (
-                <>
-                  Send 1x Xanax to{' '}
-                  <a className="underline hover:text-white" href={link} target="_blank" rel="noreferrer">
-                    Crikelz [2277924]
-                  </a>
-                  .
-                </>
-              ) : s}
-            </p>
-          </div>
-        ))}
+    <section id="how" className="section">
+      <div className="container">
+        <h2 className="text-2xl sm:text-3xl font-bold tracking-tight">How it works</h2>
+        <div className="mt-6 grid gap-4 sm:grid-cols-3">
+          {[
+            ['1. Send Xanax', 'Send 1x Xanax to Crikelz [2277924].', 'https://www.torn.com/profiles.php?XID=2277924'],
+            ['2. Wait a minute', 'Credits appear in your Blackbox balance automatically.', null],
+            ['3. Play', 'Join raffles or try Instant Wins. Payouts are instant.', null],
+          ].map(([h, s, link]) => (
+            <div key={h} className="card p-4">
+              <p className="text-sm font-semibold">{h}</p>
+              <p className="text-sm text-zinc-300">
+                {link ? (
+                  <>
+                    Send 1x Xanax to{' '}
+                    <a className="underline" href={link} target="_blank" rel="noreferrer">
+                      Crikelz [2277924]
+                    </a>
+                    .
+                  </>
+                ) : s}
+              </p>
+            </div>
+          ))}
+        </div>
       </div>
     </section>
   )

--- a/frontend/src/components/NavBar.jsx
+++ b/frontend/src/components/NavBar.jsx
@@ -9,8 +9,8 @@ export default function NavBar({ credits, loggedIn, avatarUrl, onSimLogin, onLog
       to={to}
       onClick={() => { setOpen(false); onClick?.() }}
       className={({ isActive }) =>
-        'block rounded-xl px-3 py-2 ' +
-        (isActive ? 'bg-white/10 text-white' : 'hover:bg-white/5 hover:text-white text-zinc-300')
+        'underline px-3 py-2 ' +
+        (isActive ? 'text-white' : 'text-zinc-300 hover:text-white')
       }
     >
       {label}
@@ -18,8 +18,8 @@ export default function NavBar({ credits, loggedIn, avatarUrl, onSimLogin, onLog
   )
 
   return (
-    <header className="sticky top-4 z-50 mb-6">
-      <div className="flex h-14 items-center justify-between rounded-2xl border border-white/10 bg-black/60 px-3 sm:px-4 backdrop-blur">
+    <header className="nav">
+      <div className="container flex h-14 items-center justify-between">
         <Link to="/" className="flex items-center gap-3">
           <span className="grid h-9 w-9 place-items-center rounded-lg bg-white/5 ring-1 ring-white/10">
             <svg viewBox="0 0 24 24" className="h-5 w-5" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
@@ -51,10 +51,10 @@ export default function NavBar({ credits, loggedIn, avatarUrl, onSimLogin, onLog
                 alt="Discord avatar"
                 className="h-8 w-8 rounded-full ring-1 ring-white/10"
               />
-              <button onClick={onLogout} className="rounded-xl border border-white/10 px-3 py-1.5 text-xs text-zinc-300 hover:bg-white/5">Logout</button>
+              <button onClick={onLogout} className="btn btn--ghost text-xs px-3 py-1.5">Logout</button>
             </div>
           ) : (
-            <button onClick={onSimLogin} className="rounded-2xl bg-white/10 px-4 py-2 text-sm font-semibold hover:bg-white/20 flex items-center gap-2">
+            <button onClick={onSimLogin} className="btn btn--accent flex items-center gap-2 text-sm">
               <svg viewBox="0 0 24 24" className="h-4 w-4" fill="currentColor" aria-hidden>
                 <path d="M20.317 4.369A19.791 19.791 0 0 0 16.558 3c-.2.36-.43.85-.59 1.23a18.27 18.27 0 0 0-5.936 0A7.26 7.26 0 0 0 9.44 3a19.736 19.736 0 0 0-3.76 1.369C2.409 8.205 1.563 11.94 1.875 15.63A19.9 19.9 0 0 0 7.2 18c.42-.57.8-1.18 1.13-1.82-.62-.24-1.21-.54-1.77-.9.15-.11.3-.22.44-.33 3.36 1.57 7.01 1.57 10.34 0 .15.11.3.22.45.33-.56.36-1.15.66-1.77.9.33.64.71 1.25 1.13 1.82a19.84 19.84 0 0 0 5.33-2.37c.44-4.94-.75-8.63-2.79-11.26ZM9.86 13.5c-.8 0-1.46-.73-1.46-1.62s.64-1.63 1.46-1.63c.82 0 1.48.73 1.46 1.63 0 .89-.64 1.62-1.46 1.62Zm4.29 0c-.8 0-1.46-.73-1.46-1.62s.66-1.63 1.46-1.63c.82 0 1.48.73 1.46 1.63 0 .89-.64 1.62-1.46 1.62Z" />
               </svg>
@@ -98,16 +98,16 @@ export default function NavBar({ credits, loggedIn, avatarUrl, onSimLogin, onLog
               <NavItem to="/about" label="About" />
               </div>
 
-            <div className="mt-6 border-t border-white/10 pt-4">
-              <p className="text-xs text-zinc-400">Credits: <span className="text-zinc-200">{credits}</span></p>
-              <div className="mt-3">
-                {loggedIn ? (
-                  <button onClick={() => { onLogout(); setOpen(false) }} className="w-full rounded-xl border border-white/10 px-3 py-2 text-xs text-zinc-300 hover:bg-white/5">Logout</button>
-                ) : (
-                  <button onClick={() => { onSimLogin(); setOpen(false) }} className="w-full rounded-xl bg-white/10 px-3 py-2 text-sm font-semibold hover:bg-white/20">Login (Discord)</button>
-                )}
+              <div className="mt-6 border-t border-white/10 pt-4">
+                <p className="text-xs text-zinc-400">Credits: <span className="text-zinc-200">{credits}</span></p>
+                <div className="mt-3">
+                  {loggedIn ? (
+                    <button onClick={() => { onLogout(); setOpen(false) }} className="btn btn--ghost w-full text-xs">Logout</button>
+                  ) : (
+                    <button onClick={() => { onSimLogin(); setOpen(false) }} className="btn btn--accent w-full text-sm">Login (Discord)</button>
+                  )}
+                </div>
               </div>
-            </div>
           </div>
         </div>
       )}

--- a/frontend/src/components/PromoCode.jsx
+++ b/frontend/src/components/PromoCode.jsx
@@ -2,24 +2,26 @@ import React from 'react'
 
 export default function PromoCode({ promoCode, setPromoCode, promoMsg, onRedeem }) {
   return (
-    <section id="promo" className="mt-2">
-      <div className="rounded-2xl border border-white/10 bg-white/5 p-4 sm:p-5">
-        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-          <div>
-            <h3 className="text-base sm:text-lg font-semibold">Have a code?</h3>
-            <p className="text-xs sm:text-sm text-zinc-300">Enter a promo code from Discord to claim free tickets. One per user. Abuse = ban.</p>
+    <section id="promo" className="section">
+      <div className="container">
+        <div className="card p-4 sm:p-5">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <h3 className="text-base sm:text-lg font-semibold">Have a code?</h3>
+              <p className="text-xs sm:text-sm text-zinc-300">Enter a promo code from Discord to claim free tickets. One per user. Abuse = ban.</p>
+            </div>
+            <div className="flex w-full max-w-md gap-2">
+              <input
+                value={promoCode}
+                onChange={(e) => setPromoCode(e.target.value)}
+                className="w-full rounded-xl border border-white/10 bg-black/40 px-3 py-2 text-sm placeholder:text-zinc-500"
+                placeholder="Enter code e.g. KAILIN-IS-A-NERD"
+              />
+              <button onClick={onRedeem} className="btn btn--accent w-full sm:w-auto">Redeem</button>
+            </div>
           </div>
-          <div className="flex w-full max-w-md gap-2">
-            <input
-              value={promoCode}
-              onChange={(e) => setPromoCode(e.target.value)}
-              className="w-full rounded-xl border border-white/10 bg-black/40 px-3 py-2 text-sm outline-none placeholder:text-zinc-500"
-              placeholder="Enter code e.g. KAILIN-IS-A-NERD"
-            />
-            <button onClick={onRedeem} className="w-full sm:w-auto rounded-xl bg-white px-4 py-2 text-sm font-bold text-black">Redeem</button>
-          </div>
+          <p className="mt-2 text-sm text-zinc-400" role="status">{promoMsg}</p>
         </div>
-        <p className="mt-2 text-sm text-zinc-400" role="status">{promoMsg}</p>
       </div>
     </section>
   )

--- a/frontend/src/components/WinnersTicker.jsx
+++ b/frontend/src/components/WinnersTicker.jsx
@@ -1,0 +1,24 @@
+import React from 'react'
+
+const defaultItems = [
+  { name: 'Minty_Minxy', prize: '$5m' },
+  { name: 'Shmichael', prize: 'Faction Honour Crown' },
+  { name: 'kaiLin', prize: '$100m' },
+  { name: 'SomePlayer', prize: 'Donator Pack' },
+  { name: 'AnotherOne', prize: '$50m' },
+]
+
+export default function WinnersTicker({ items = defaultItems }) {
+  const list = [...items, ...items]
+  return (
+    <div className="ticker" aria-label="recent winners">
+      <div className="ticker__row">
+        {list.map((w, i) => (
+          <span key={i} className="whitespace-nowrap">
+            {w.name} won {w.prize}
+          </span>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/ui/Button.jsx
+++ b/frontend/src/components/ui/Button.jsx
@@ -1,9 +1,9 @@
 export default function Button({ variant = "primary", className = "", as = "button", ...props }) {
-  const base = "inline-flex items-center justify-center rounded-2xl px-4 py-2 text-sm font-medium focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-white/60 ring-offset-black/0";
+  const base = "btn";
   const styles = {
-    primary: "bg-white text-black hover:bg-white/90",
-    secondary: "border border-white/20 text-white hover:bg-white/5",
-    ghost: "text-white/80 hover:text-white"
+    primary: "btn--accent",
+    secondary: "btn--ghost",
+    ghost: "btn--ghost",
   };
   const Component = as;
   return <Component className={`${base} ${styles[variant]} ${className}`} {...props} />;

--- a/frontend/src/components/ui/Card.jsx
+++ b/frontend/src/components/ui/Card.jsx
@@ -1,3 +1,3 @@
 export default function Card({ children, className = "" }) {
-  return <div className={`rounded-2xl border border-white/10 bg-white/5 ${className}`}>{children}</div>;
+  return <div className={`card ${className}`}>{children}</div>;
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -4,20 +4,110 @@
 @tailwind components;
 @tailwind utilities;
 
-/* progress styling */
-progress {
-  appearance: none;
-  width: 100%;
-  height: 4px;
-  border-radius: 9999px;
-  overflow: hidden;
+:root{
+  --bg-0:#0c0c0e;
+  --bg-1:#111114;
+  --bg-2:#15161a;
+  --text-0:#e9e9ed;
+  --text-1:#b7b9c0;
+  --muted:#7a7f87;
+  --accent:#7CF0BD; /* single brand accent; keep */
+  --card-bd:rgba(255,255,255,.06);
+  --card-hi:rgba(255,255,255,.12);
+  --ring: 0 0 0 2px var(--accent);
+  --radius:14px;
+  --dur:120ms;
 }
-progress::-webkit-progress-bar {
-  background: rgba(255, 255, 255, 0.1);
+
+html,body,#root{height:100%}
+body{
+  color:var(--text-0);
+  background:
+    radial-gradient(80% 60% at 30% -10%, #1a1c22 0%, transparent 60%),
+    radial-gradient(70% 50% at 100% 0%, #11131a 0%, transparent 55%),
+    var(--bg-0);
+  -webkit-font-smoothing:antialiased;
+  -moz-osx-font-smoothing:grayscale;
 }
-progress::-webkit-progress-value {
-  background: rgba(255, 255, 255, 0.7);
+
+/* ultra-low noise overlay for texture */
+body::before{
+  content:"";
+  position:fixed; inset:0; pointer-events:none; z-index:-1;
+  background-image:url("data:image/svg+xml;utf8,\
+  <svg xmlns='http://www.w3.org/2000/svg' width='160' height='160' viewBox='0 0 160 160'>\
+  <filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='3' /></filter>\
+  <rect width='100%' height='100%' filter='url(%23n)' opacity='0.035'/></svg>");
+  mix-blend-mode:soft-light;
 }
-progress::-moz-progress-bar {
-  background: rgba(255, 255, 255, 0.7);
+
+/* layout rhythm */
+.container{ max-width:1180px; margin:0 auto; padding:0 20px; }
+.section{ padding:48px 0; }
+.section + .section{ border-top:1px solid rgba(255,255,255,.07); }
+
+/* navigation (sticky glass) */
+.nav{
+  position:sticky; top:0; z-index:40;
+  backdrop-filter:saturate(120%) blur(8px);
+  background:linear-gradient(180deg, rgba(17,17,20,.85), rgba(17,17,20,.65));
+  border-bottom:1px solid rgba(255,255,255,.07);
 }
+
+/* cards */
+.card{
+  background:linear-gradient(180deg, var(--bg-1), var(--bg-2));
+  border:1px solid var(--card-bd);
+  border-radius:var(--radius);
+  box-shadow: inset 0 1px 0 var(--card-hi);
+  transition: transform var(--dur) ease, border-color var(--dur) ease, box-shadow var(--dur) ease;
+}
+.card:hover{ transform:translateY(-2px); border-color:rgba(255,255,255,.14); }
+.card:focus-within{ outline:var(--ring); outline-offset:2px; }
+
+/* buttons */
+.btn{
+  background:#fff; color:#111; border-radius:999px; padding:10px 16px;
+  border:0; transition:transform var(--dur) ease, opacity var(--dur) ease, box-shadow var(--dur) ease;
+}
+.btn:hover{ transform:translateY(-1px); }
+.btn:active{ transform:translateY(0); opacity:.95; }
+.btn--ghost{ background:transparent; color:var(--text-0); border:1px solid var(--card-bd); }
+.btn--accent{ background:var(--accent); color:#101213; box-shadow:0 0 0 0 rgba(124,240,189,.6); }
+.btn--accent:hover{ box-shadow:0 0 0 6px rgba(124,240,189,.08); }
+
+/* progress bars */
+.progress{
+  height:6px; border-radius:999px; background:rgba(255,255,255,.06); overflow:hidden;
+}
+.progress__bar{
+  height:100%; width:0%;
+  background:
+    linear-gradient(90deg, rgba(255,255,255,.25), rgba(255,255,255,0) 40%) center/16px 100% no-repeat,
+    linear-gradient(90deg, var(--accent), #5dd9a2);
+  transition:width 300ms ease;
+}
+
+/* links underline animation */
+a{ color:var(--text-0); text-decoration:none; }
+a.underline{
+  background:linear-gradient(currentColor,currentColor) center bottom/0 2px no-repeat;
+  transition:background-size var(--dur) ease,color var(--dur) ease;
+}
+a.underline:hover{ color:#fff; background-size:100% 2px; }
+
+/* accordion chevron */
+.accordion__chev{ transition: transform var(--dur) ease; }
+details[open] .accordion__chev{ transform:rotate(180deg); }
+
+/* focus-visible */
+:where(button, [href], input, select, textarea, [tabindex]):focus-visible{
+  outline:var(--ring);
+  outline-offset:2px;
+}
+
+/* ticker */
+.ticker{ height:36px; overflow:hidden; color:var(--muted); }
+.ticker__row{ display:flex; align-items:center; gap:32px; white-space:nowrap; animation:ticker 30s linear infinite; }
+.ticker:hover .ticker__row{ animation-play-state:paused; }
+@keyframes ticker{ to{ transform:translateX(-50%); } }

--- a/frontend/src/pages/About.jsx
+++ b/frontend/src/pages/About.jsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import Card from '@/components/ui/Card.jsx';
 
 export default function About() {
@@ -15,37 +14,39 @@ export default function About() {
     { q: 'Where can I ask more questions?', a: 'Join our Discord server and ping a mod — we answer fast.' },
   ];
   return (
-    <section className="mt-10 space-y-12">
-      <div>
-        <h1 className="text-3xl font-bold tracking-tight mb-4">About BlackBox Casino</h1>
-        <Card className="p-6 md:p-8 space-y-4 text-sm">
-          <p>BlackBox Casino was created by Torn players, for Torn players. Our goal has always been simple: run a fair, transparent casino that people can trust.</p>
-          <p>Every raffle, giveaway, and payout is logged publicly on the Torn forums and in our Discord. If you win, you’ll see it announced, verified, and paid in full.</p>
-          <p>Since opening, we’ve delivered prizes ranging from Donator Packs and rare collectibles to Private Islands and billions in Torn cash. Our track record speaks for itself: no missed payouts, no excuses, no scams.</p>
-          <p>At BlackBox Casino, you’re part of a community that values fairness and integrity. That’s what sets us apart.</p>
-        </Card>
-      </div>
-      <div>
-        <h2 className="text-2xl font-bold tracking-tight">Team</h2>
-        <div className="mt-4 grid gap-4 sm:grid-cols-3">
-          {team.map((m) => (
-            <Card key={m.role} className="p-6 md:p-8">
-              <p className="text-xs uppercase tracking-wider text-zinc-400">{m.role}</p>
-              <h3 className="mt-1 text-sm font-semibold">{m.name}{m.xid && <span className="text-zinc-400"> [{m.xid}]</span>}</h3>
-              <p className="mt-1 text-sm text-zinc-300">{m.desc}</p>
-              {m.xid && (
-                <a className="mt-2 inline-block text-xs underline text-zinc-300 hover:text-white" href={`https://www.torn.com/profiles.php?XID=${m.xid}`}>Open profile</a>
-              )}
-            </Card>
-          ))}
+    <section className="section">
+      <div className="container space-y-12">
+        <div>
+          <h1 className="text-3xl font-bold tracking-tight mb-4">About BlackBox Casino</h1>
+          <Card className="p-6 md:p-8 space-y-4 text-sm">
+            <p>BlackBox Casino was created by Torn players, for Torn players. Our goal has always been simple: run a fair, transparent casino that people can trust.</p>
+            <p>Every raffle, giveaway, and payout is logged publicly on the Torn forums and in our Discord. If you win, you’ll see it announced, verified, and paid in full.</p>
+            <p>Since opening, we’ve delivered prizes ranging from Donator Packs and rare collectibles to Private Islands and billions in Torn cash. Our track record speaks for itself: no missed payouts, no excuses, no scams.</p>
+            <p>At BlackBox Casino, you’re part of a community that values fairness and integrity. That’s what sets us apart.</p>
+          </Card>
         </div>
-      </div>
-      <div>
-        <h2 className="text-2xl font-bold tracking-tight">FAQ</h2>
-        <div className="mt-4 space-y-2">
-          {faqs.map((f, i) => (
-            <FAQItem key={i} {...f} />
-          ))}
+        <div>
+          <h2 className="text-2xl font-bold tracking-tight">Team</h2>
+          <div className="mt-4 grid gap-4 sm:grid-cols-3">
+            {team.map((m) => (
+              <Card key={m.role} className="p-6 md:p-8">
+                <p className="text-xs uppercase tracking-wider text-zinc-400">{m.role}</p>
+                <h3 className="mt-1 text-sm font-semibold">{m.name}{m.xid && <span className="text-zinc-400"> [{m.xid}]</span>}</h3>
+                <p className="mt-1 text-sm text-zinc-300">{m.desc}</p>
+                {m.xid && (
+                  <a className="mt-2 inline-block text-xs underline text-zinc-300" href={`https://www.torn.com/profiles.php?XID=${m.xid}`}>Open profile</a>
+                )}
+              </Card>
+            ))}
+          </div>
+        </div>
+        <div>
+          <h2 className="text-2xl font-bold tracking-tight">FAQ</h2>
+          <div className="mt-4 space-y-2">
+            {faqs.map((f, i) => (
+              <FAQItem key={i} {...f} />
+            ))}
+          </div>
         </div>
       </div>
     </section>
@@ -53,17 +54,13 @@ export default function About() {
 }
 
 function FAQItem({ q, a }) {
-  const [open, setOpen] = useState(false);
   return (
-    <Card className="p-4">
-      <button
-        className="flex w-full items-center justify-between text-left text-sm font-medium"
-        onClick={() => setOpen((o) => !o)}
-      >
+    <details className="card p-4">
+      <summary className="flex w-full items-center justify-between text-left text-sm font-medium cursor-pointer list-none">
         <span>{q}</span>
-        <span aria-hidden>{open ? '−' : '+'}</span>
-      </button>
-      {open && <p className="mt-2 text-sm text-zinc-300">{a}</p>}
-    </Card>
+        <span className="accordion__chev" aria-hidden>⌄</span>
+      </summary>
+      <p className="mt-2 text-sm text-zinc-300">{a}</p>
+    </details>
   );
 }

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -2,36 +2,42 @@ import React from 'react'
 import PromoCode from '@/components/PromoCode.jsx'
 import { Link } from 'react-router-dom'
 import Button from '@/components/ui/Button.jsx'
+import WinnersTicker from '@/components/WinnersTicker.jsx'
 
-export default function Home({ promoCode, setPromoCode, promoMsg, onRedeem }) {
+export default function Home({ promoCode, setPromoCode, promoMsg, onRedeem, winners = [] }) {
   return (
     <>
-      <section className="relative">
-        <div className="grid gap-6 lg:grid-cols-[1.6fr_1fr]">
-          <div>
-            <h1 className="text-[clamp(2rem,6vw,3.5rem)] font-black leading-[1.05] tracking-tight">
-              Torn-only raffles, instant wins, <span className="text-transparent bg-clip-text bg-gradient-to-r from-white via-zinc-200 to-white">zero fluff</span>.
-            </h1>
-            <p className="mt-3 text-sm sm:text-base text-zinc-300">Community-run. Fast credits. Draws you can verify. We never ask for your Torn API key.</p>
-            <div className="mt-5 flex flex-wrap items-center gap-3">
-              <Button as="a" href="https://www.torn.com/profiles.php?XID=2277924" variant="primary">Open Crikelz [2277924]</Button>
-              <Button as={Link} to="/how" variant="secondary">How it works</Button>
+      <section className="section">
+        <div className="container relative">
+          <div className="grid gap-6 lg:grid-cols-[1.6fr_1fr]">
+            <div>
+              <h1 className="text-[clamp(2.25rem,6vw,3.875rem)] font-black leading-[1.05] tracking-tight">
+                Torn-only raffles, instant wins, <span className="text-transparent bg-clip-text bg-gradient-to-r from-white via-zinc-200 to-white">zero fluff</span>.
+              </h1>
+              <p className="mt-3 text-sm sm:text-base text-zinc-300">Community-run. Fast credits. Draws you can verify. We never ask for your Torn API key.</p>
+              <div className="mt-5 flex flex-wrap items-center gap-3">
+                <Button as="a" href="https://www.torn.com/profiles.php?XID=2277924" variant="primary">Open Crikelz [2277924]</Button>
+                <Button as={Link} to="/how" variant="secondary">How it works</Button>
+              </div>
+              <div className="mt-6 flex flex-wrap gap-3">
+                {[
+                  ['Discord OAuth Only'],
+                  ['Fast Credit Top-ups'],
+                  ['Verifiable Draws'],
+                  ['Unofficial & Community-run'],
+                ].map((label) => (
+                  <Button key={label} variant="ghost" className="text-xs px-3 py-1">
+                    {label}
+                  </Button>
+                ))}
+              </div>
             </div>
-            <div className="mt-6 flex flex-wrap gap-3">
-              {[
-                ['Discord OAuth Only'],
-                ['Fast Credit Top-ups'],
-                ['Verifiable Draws'],
-                ['Unofficial & Community-run'],
-              ].map((label) => (
-                <Button key={label} variant="ghost" className="text-xs px-3 py-1">
-                  {label}
-                </Button>
-              ))}
+            <div className="aspect-[16/10] w-full overflow-hidden rounded-2xl border border-white/10 bg-gradient-to-br from-zinc-800 to-zinc-900 grid place-items-center">
+              <p className="text-sm text-zinc-400">AI banner placeholder (casino vibe, no Torn IP)</p>
             </div>
           </div>
-          <div className="aspect-[16/10] w-full overflow-hidden rounded-2xl border border-white/10 bg-gradient-to-br from-zinc-800 to-zinc-900 grid place-items-center">
-            <p className="text-sm text-zinc-400">AI banner placeholder (casino vibe, no Torn IP)</p>
+          <div className="mt-6">
+            <WinnersTicker items={winners} />
           </div>
         </div>
       </section>

--- a/frontend/src/pages/Raffles.jsx
+++ b/frontend/src/pages/Raffles.jsx
@@ -8,63 +8,70 @@ export default function Raffles({ raffles = [] }) {
     ['Luxury', 'Donator Pack', 'Premium prize pool for big spenders.'],
   ];
   return (
-    <section className="mt-10 space-y-12">
-      <div className="flex items-end justify-between">
+    <section className="section">
+      <div className="container space-y-12">
+        <div className="flex items-end justify-between">
+          <div>
+            <h1 className="text-3xl font-bold tracking-tight">Live raffles (mock)</h1>
+            <p className="text-zinc-400">UI only — wired to backend later.</p>
+          </div>
+        </div>
+        {raffles.length === 0 ? (
+          <div className="flex flex-col items-center py-20 text-center">
+            <svg className="h-12 w-12 text-white/40" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="1.5"><circle cx="12" cy="12" r="9" /><path d="M9 12h6"/><path d="M12 9v6"/></svg>
+            <p className="mt-4 text-sm text-zinc-300">No raffles live right now.</p>
+            <Button as="a" href="https://discord.gg" className="mt-4" variant="primary">Join our Discord</Button>
+          </div>
+        ) : (
+          <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-4">
+            {raffles.map((r) => {
+              const pct = Math.round((r.value / r.max) * 100);
+              return (
+                <Card key={r.id} className="p-6 md:p-8">
+                  <div className="aspect-[16/10] rounded-xl bg-gradient-to-br from-zinc-800 to-zinc-900 grid place-items-center">
+                    <svg viewBox="0 0 24 24" className="h-12 w-12 opacity-60" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+                      <path d="M3 7l9 5 9-5" />
+                      <path d="M21 17l-9 5-9-5" />
+                      <path d="M3 7l9-5 9 5-9 5-9-5z" />
+                      <path d="M3 7v10l9 5 9-5V7" />
+                    </svg>
+                  </div>
+                  <div className="mt-4 flex items-start justify-between gap-3">
+                    <div>
+                      <p className="text-[11px] uppercase tracking-widest text-zinc-400">{r.kind}</p>
+                      <h3 className="mt-1 text-lg font-semibold leading-tight">{r.title}</h3>
+                    </div>
+                    <span className="rounded-full bg-white/10 px-3 py-1 text-xs">{r.badge}</span>
+                  </div>
+                  <div className="mt-4">
+                    <div className="progress" aria-label="progress">
+                      <div className="progress__bar" style={{ width: `${pct}%` }}></div>
+                    </div>
+                    <div className="mt-2 flex items-center justify-between text-xs text-zinc-400">
+                      <span>{r.value} sold</span>
+                      <span>{pct}%</span>
+                    </div>
+                  </div>
+                  <div className="mt-6 flex items-center gap-2">
+                    <Button className="flex-1" variant="primary">{r.kind === 'Raffle' ? 'Join' : 'Play'}</Button>
+                    <Button variant="secondary">Details</Button>
+                  </div>
+                </Card>
+              );
+            })}
+          </div>
+        )}
         <div>
-          <h1 className="text-3xl font-bold tracking-tight">Live raffles (mock)</h1>
-          <p className="text-zinc-400">UI only — wired to backend later.</p>
-        </div>
-      </div>
-      {raffles.length === 0 ? (
-        <div className="flex flex-col items-center py-20 text-center">
-          <svg className="h-12 w-12 text-white/40" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="1.5"><circle cx="12" cy="12" r="9" /><path d="M9 12h6"/><path d="M12 9v6"/></svg>
-          <p className="mt-4 text-sm text-zinc-300">No raffles live right now.</p>
-          <Button as="a" href="https://discord.gg" className="mt-4" variant="primary">Join our Discord</Button>
-        </div>
-      ) : (
-        <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-4">
-          {raffles.map((r) => (
-            <Card key={r.id} className="p-6 md:p-8">
-              <div className="aspect-[16/10] rounded-xl bg-gradient-to-br from-zinc-800 to-zinc-900 grid place-items-center">
-                <svg viewBox="0 0 24 24" className="h-12 w-12 opacity-60" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
-                  <path d="M3 7l9 5 9-5" />
-                  <path d="M21 17l-9 5-9-5" />
-                  <path d="M3 7l9-5 9 5-9 5-9-5z" />
-                  <path d="M3 7v10l9 5 9-5V7" />
-                </svg>
-              </div>
-              <div className="mt-4 flex items-start justify-between gap-3">
-                <div>
-                  <p className="text-[11px] uppercase tracking-widest text-zinc-400">{r.kind}</p>
-                  <h3 className="mt-1 text-lg font-semibold leading-tight">{r.title}</h3>
-                </div>
-                <span className="rounded-full bg-white/10 px-3 py-1 text-xs">{r.badge}</span>
-              </div>
-              <div className="mt-4">
-                <progress max={r.max} value={r.value} />
-                <div className="mt-2 flex items-center justify-between text-xs text-zinc-400">
-                  <span>{r.value} sold</span>
-                  <span>{Math.round((r.value / r.max) * 100)}%</span>
-                </div>
-              </div>
-              <div className="mt-6 flex items-center gap-2">
-                <Button className="flex-1" variant="primary">{r.kind === 'Raffle' ? 'Join' : 'Play'}</Button>
-                <Button variant="secondary">Details</Button>
-              </div>
-            </Card>
-          ))}
-        </div>
-      )}
-      <div>
-        <h2 className="text-2xl font-bold tracking-tight">Seasonal items</h2>
-        <div className="mt-6 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-          {seasonal.map(([cat, title, desc]) => (
-            <Card key={title} className="p-6 md:p-8">
-              <p className="text-xs uppercase tracking-wider text-zinc-400">{cat}</p>
-              <p className="mt-1 text-sm font-semibold">{title}</p>
-              <p className="mt-1 text-sm text-zinc-300">{desc}</p>
-            </Card>
-          ))}
+          <h2 className="text-2xl font-bold tracking-tight">Seasonal items</h2>
+          <div className="mt-6 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+            {seasonal.map(([cat, title, desc]) => (
+              <Card key={title} className="p-6 md:p-8">
+                <p className="text-xs uppercase tracking-wider text-zinc-400">{cat}</p>
+                <p className="mt-1 text-sm font-semibold">{title}</p>
+                <p className="mt-1 text-sm text-zinc-300">{desc}</p>
+              </Card>
+            ))}
+          </div>
         </div>
       </div>
     </section>

--- a/frontend/src/pages/Winners.jsx
+++ b/frontend/src/pages/Winners.jsx
@@ -2,32 +2,34 @@ import Card from '@/components/ui/Card.jsx';
 
 export default function Winners({ winners = [] }) {
   return (
-    <section className="mt-10">
-      <div className="mb-4 flex items-center justify-between">
-        <h1 className="text-3xl font-bold tracking-tight">Recent winners</h1>
-        <a href="#" className="hidden md:inline text-sm text-zinc-300 hover:text-white">Full history →</a>
-      </div>
-      <div className="hidden md:block overflow-hidden rounded-2xl border border-white/10">
-        <table className="w-full text-sm">
-          <thead className="bg-white/5 text-left text-zinc-300">
-            <tr>
-              <th className="px-4 py-3">When</th>
-              <th className="px-4 py-3">Player</th>
-              <th className="px-4 py-3">Prize</th>
-              <th className="px-4 py-3">Raffle</th>
-            </tr>
-          </thead>
-          <tbody className="divide-y divide-white/5">
-            {winners.map((w) => (
-              <WinnerRow key={w.xid} {...w} />
-            ))}
-          </tbody>
-        </table>
-      </div>
-      <div className="md:hidden space-y-3">
-        {winners.map((w) => (
-          <WinnerRow key={w.xid + '-m'} {...w} />
-        ))}
+    <section className="section">
+      <div className="container">
+        <div className="mb-4 flex items-center justify-between">
+          <h1 className="text-3xl font-bold tracking-tight">Recent winners</h1>
+          <a href="#" className="hidden md:inline text-sm underline">Full history →</a>
+        </div>
+        <div className="hidden md:block overflow-hidden card">
+          <table className="w-full text-sm">
+            <thead className="bg-white/5 text-left text-zinc-300">
+              <tr>
+                <th className="px-4 py-3">When</th>
+                <th className="px-4 py-3">Player</th>
+                <th className="px-4 py-3">Prize</th>
+                <th className="px-4 py-3">Raffle</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-white/5">
+              {winners.map((w) => (
+                <WinnerRow key={w.xid} {...w} />
+              ))}
+            </tbody>
+          </table>
+        </div>
+        <div className="md:hidden space-y-3">
+          {winners.map((w) => (
+            <WinnerRow key={w.xid + '-m'} {...w} />
+          ))}
+        </div>
       </div>
     </section>
   );
@@ -39,7 +41,7 @@ function WinnerRow({ when, name, xid, prize, raffle }) {
       <tr className="hidden md:table-row">
         <td className="px-4 py-3">{when}</td>
         <td className="px-4 py-3">
-          <a className="underline hover:text-white" target="_blank" rel="noopener noreferrer" href={`https://www.torn.com/profiles.php?XID=${xid}`}>
+          <a className="underline" target="_blank" rel="noopener noreferrer" href={`https://www.torn.com/profiles.php?XID=${xid}`}>
             {`${name} [${xid}]`}
           </a>
         </td>


### PR DESCRIPTION
## Summary
- add global design tokens, cards, buttons and progress bar styles
- implement sticky glass navbar with focus rings and animated links
- introduce winners ticker and apply new styling across pages

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af20c70dc0832fb06a7fa942c999ba